### PR TITLE
Fix typos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 # TODO
 
 - [ ] Add a parameter to `settimed` for quickly visualizing 48 hours of wallpaper switching. Right now, debugging is too time-consuming.
-- [ ] Implement the equivivalent of `xsetroot -bitmap` + image conversion.
+- [ ] Implement the equivalent of `xsetroot -bitmap` + image conversion.

--- a/cmd/getdpi/README.md
+++ b/cmd/getdpi/README.md
@@ -8,11 +8,11 @@ Tool for retrieving the average DPI across all monitors, regardless of if X or W
 
 ## Usage
 
-Retreive the average DPI as a pair of numbers (ie. `96x96`):
+Retrieve the average DPI as a pair of numbers (ie. `96x96`):
 
     getdpi -b
 
-Retreive the average DPI as a single number (ie. `96`):
+Retrieve the average DPI as a single number (ie. `96`):
 
     getdpi
 

--- a/cmd/vram/README.md
+++ b/cmd/vram/README.md
@@ -8,7 +8,7 @@ Tool for retrieving the average amount of VRAM across all GPUs, or list all avai
 
 ## Usage
 
-Retreive the average VRAM as a number, followed by ` MiB`:
+Retrieve the average VRAM as a number, followed by ` MiB`:
 
     vram
 

--- a/pkg/gnometimed/convert.go
+++ b/pkg/gnometimed/convert.go
@@ -12,7 +12,7 @@ const simpleTimedWallpaperFormatVersion = "1.0"
 
 // GnomeToSimple converts a Gnome Timed Wallpaper to a Simple Timed Wallpaper
 func GnomeToSimple(gtw *Wallpaper) (*simpletimed.Wallpaper, error) {
-	// TODO: Convert from struct to struct, without excercising the serializer and the parser
+	// TODO: Convert from struct to struct, without exercising the serializer and the parser
 
 	// Convert the given struct to the string contents of a simpletimed.Wallpaper file
 	s, err := GnomeToSimpleString(gtw)


### PR DESCRIPTION
Found via `codespell -S vendor -L statics,xwindows,hass,nnumber`